### PR TITLE
Fixing EnvEvent assignments that cause failed field discriminant checks.

### DIFF
--- a/src/dotenv/private/envparser.nim
+++ b/src/dotenv/private/envparser.nim
@@ -255,7 +255,7 @@ proc ignoreMsg*(c: EnvParser, e: EnvEvent): string =
 
 proc getKeyValPair(c: var EnvParser, kind: EnvEventKind): EnvEvent =
   if c.tok.kind == EnvTokenKind.Symbol:
-    result.kind = kind
+    result = EnvEvent(kind: kind)
     result.key = c.tok.literal
     result.value = ""
     rawGetTok(c, c.tok)
@@ -270,16 +270,14 @@ proc getKeyValPair(c: var EnvParser, kind: EnvEventKind): EnvEvent =
       if c.tok.kind == EnvTokenKind.Symbol:
         result.value = c.tok.literal
       else:
-        reset result
-        result.kind = EnvEventKind.Error
+        result = EnvEvent(kind: EnvEventKind.Error)
         result.msg = errorStr(c, "symbol expected, but found: " & c.tok.literal)
       rawGetTok(c, c.tok)
     else:
-      reset result
-      result.kind = EnvEventKind.Error
+      result = EnvEvent(kind: EnvEventKind.Error)
       result.msg = errorStr(c, "symbol expected, but found: " & c.tok.literal)
   else:
-    result.kind = EnvEventKind.Error
+    result = EnvEvent(kind: EnvEventKind.Error)
     result.msg = errorStr(c, "symbol expected, but found: " & c.tok.literal)
     rawGetTok(c, c.tok)
 
@@ -287,10 +285,10 @@ proc next*(c: var EnvParser): EnvEvent =
   ## retrieves the first/next event. This controls the parser.
   case c.tok.kind
   of EnvTokenKind.Eof:
-    result.kind = EnvEventKind.Eof
+    result = EnvEvent(kind: EnvEventKind.Eof)
   of EnvTokenKind.Symbol:
     result = getKeyValPair(c, EnvEventKind.KeyValuePair)
   of EnvTokenKind.Invalid, EnvTokenKind.Equals:
-    result.kind = EnvEventKind.Error
+    result = EnvEvent(kind: EnvEventKind.Error)
     result.msg = errorStr(c, "invalid token: " & c.tok.literal)
     rawGetTok(c, c.tok)


### PR DESCRIPTION
Firstly, thanks for the package, friendo!

However, it seems that Nim has gotten a bit more strict since this package was created when it comes to modifying fields that are used to branch variant objects (ie. `kind` fields).

Running the current test suite with Nim v0.20.0 returns warnings and errors like the following:

```
/opt/dotenv/src/dotenv/private/envparser.nim(291, 17) Warning: Potential object case transition, instantiate new object instead [CaseTransition]
...
/opt/dotenv/tests/main.nim(6) main
/opt/dotenv/src/dotenv.nim(53) load
/opt/dotenv/src/dotenv/private/envparser.nim(293) next
/opt/dotenv/src/dotenv/private/envparser.nim(259) getKeyValPair
/home/vagrant/.choosenim/toolchains/nim-0.20.0/lib/system/assign.nim(243) FieldDiscriminantCheck
/home/vagrant/.choosenim/toolchains/nim-0.20.0/lib/system/fatal.nim(39) sysFatal

    Unhandled exception: assignment to discriminant changes object branch; compile with -d:nimOldCaseObjects for a transition period [FieldError]
  [FAILED] load simple environment variables from .env with full directory and file name
```

It seems that creating new `EnvEvent` objects instead of resetting them fixes those errors.